### PR TITLE
Add supporting 2.4 version of EBICS

### DIFF
--- a/lib/epics.rb
+++ b/lib/epics.rb
@@ -10,6 +10,7 @@ require 'faraday'
 require 'securerandom'
 require 'time'
 require "epics/version"
+require "epics/keyring"
 require "epics/key"
 require "epics/response"
 require "epics/error"

--- a/lib/epics/header_request.rb
+++ b/lib/epics/header_request.rb
@@ -22,6 +22,7 @@ class Epics::HeaderRequest
           xml.Product(client.product_name, 'Language' => client.locale)
           xml.OrderDetails {
             xml.OrderType options[:order_type]
+            xml.OrderID b36encode(client.next_order_id) if client.version == Epics::Keyring::VERSION_24
             xml.OrderAttribute options[:order_attribute]
             xml.StandardOrderParams {
               build_attributes(xml, options[:order_params])
@@ -54,5 +55,9 @@ class Epics::HeaderRequest
         xml.send(key, value)
       end
     end
+  end
+  
+  def b36encode(number)
+    number.to_s(36).upcase.rjust(4, '0')
   end
 end

--- a/lib/epics/hia.rb
+++ b/lib/epics/hia.rb
@@ -27,7 +27,7 @@ class Epics::HIA < Epics::GenericRequest
     x_509_certificate_e = client.x_509_certificate_e
 
     Nokogiri::XML::Builder.new do |xml|
-      xml.HIARequestOrderData('xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#', 'xmlns' => 'urn:org:ebics:H004') {
+      xml.HIARequestOrderData('xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#', 'xmlns' => client.urn_schema) {
         xml.AuthenticationPubKeyInfo {
           if x_509_certificate_x
             xml.send('ds:X509Data') do
@@ -72,7 +72,7 @@ class Epics::HIA < Epics::GenericRequest
 
   def to_xml
     Nokogiri::XML::Builder.new do |xml|
-      xml.send(root, 'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#', 'xmlns' => 'urn:org:ebics:H004', 'Version' => 'H004', 'Revision' => '1') {
+      xml.send(root, 'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#', 'xmlns' => client.urn_schema, 'Version' => client.version, 'Revision' => '1') {
         xml.parent.add_child(header)
         xml.parent.add_child(body)
       }

--- a/lib/epics/ini.rb
+++ b/lib/epics/ini.rb
@@ -54,7 +54,7 @@ class Epics::INI < Epics::GenericRequest
 
   def to_xml
     Nokogiri::XML::Builder.new do |xml|
-      xml.send(root, 'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#', 'xmlns' => 'urn:org:ebics:H004', 'Version' => 'H004', 'Revision' => '1') {
+      xml.send(root, 'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#', 'xmlns' => client.urn_schema, 'Version' => client.version, 'Revision' => '1') {
         xml.parent.add_child(header)
         xml.parent.add_child(body)
       }

--- a/lib/epics/keyring.rb
+++ b/lib/epics/keyring.rb
@@ -1,0 +1,14 @@
+class Epics::Keyring
+  VERSION_24 = 'H003'
+  VERSION_25 = 'H004'
+  
+  SUPPORTED_VERSIONS = [VERSION_24, VERSION_25]
+  
+  attr_reader :version
+  
+  def initialize(version)
+    raise ArgumentError, "Unsupported version: #{version}" unless SUPPORTED_VERSIONS.include?(version)
+    
+    @version = version
+  end
+end

--- a/spec/orders/hia_spec.rb
+++ b/spec/orders/hia_spec.rb
@@ -50,5 +50,32 @@ RSpec.describe Epics::HIA do
         expect(subject.order_data).to include("<ds:X509Certificate>#{e_crt.data}</ds:X509Certificate>")
       end
     end
+    
+    context 'when EBICS version is 2.4' do
+      let(:client) do
+        Epics::Client.new(key, 'secret', 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS', options)
+      end
+      let(:options) { {version: Epics::Keyring::VERSION_24} }
+      
+      it 'includes the correct OrderID in the headers' do
+        expect(subject.header.to_xml).to include("<OrderID>A001</OrderID>")
+      end
+      
+      it 'includes the correct urn schema and version' do
+        expect(subject.to_xml).to include('xmlns="http://www.ebics.org/H003"')
+        expect(subject.to_xml).to include('Version="H003"')
+      end
+    end
+    
+    context 'when EBICS version is 2.5' do
+      it 'does not include the OrderID in the headers' do
+        expect(subject.header.to_xml).not_to include("<OrderID>A001</OrderID>")
+      end
+      
+      it 'includes the correct urn schema' do
+        expect(subject.to_xml).to include('xmlns="urn:org:ebics:H004"')
+        expect(subject.to_xml).to include('Version="H004"')
+      end
+    end
   end
 end

--- a/spec/orders/ini_spec.rb
+++ b/spec/orders/ini_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe Epics::INI do
+  subject { described_class.new(client) }
+  
   let(:client) { Epics::Client.new(key, 'secret', 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS') }
   let(:key) { File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'SIZBN001.key')) }
-  before { allow(subject).to receive(:timestamp) { '2014-10-10T11:16:00Z' } }
 
-  subject { described_class.new(client) }
+  before { allow(subject).to receive(:timestamp) { '2014-10-10T11:16:00Z' } }
 
   describe '#to_xml' do
     specify { expect(subject.to_xml).to be_a_valid_ebics_doc }
@@ -46,6 +47,33 @@ RSpec.describe Epics::INI do
         expect(subject.key_signature).to include('<ds:X509IssuerName>/C=GB/O=TestOrg/CN=test.example.org</ds:X509IssuerName>')
         expect(subject.key_signature).to include('<ds:X509SerialNumber>2</ds:X509SerialNumber>')
         expect(subject.key_signature).to include("<ds:X509Certificate>#{a_crt.data}</ds:X509Certificate>")
+      end
+    end
+    
+    context 'when EBICS version is 2.4' do
+      let(:client) do
+        Epics::Client.new(key, 'secret', 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS', options)
+      end
+      let(:options) { {version: Epics::Keyring::VERSION_24} }
+      
+      it 'includes the correct OrderID in the headers' do
+        expect(subject.header.to_xml).to include("<OrderID>A001</OrderID>")
+      end
+      
+      it 'includes the correct urn schema and version' do
+        expect(subject.to_xml).to include('xmlns="http://www.ebics.org/H003"')
+        expect(subject.to_xml).to include('Version="H003"')
+      end
+    end
+    
+    context 'when EBICS version is 2.5' do
+      it 'does not include the OrderID in the headers' do
+        expect(subject.header.to_xml).not_to include("<OrderID>A001</OrderID>")
+      end
+      
+      it 'includes the correct urn schema' do
+        expect(subject.to_xml).to include('xmlns="urn:org:ebics:H004"')
+        expect(subject.to_xml).to include('Version="H004"')
       end
     end
   end


### PR DESCRIPTION
The changes were extracted from [PR](https://github.com/railslove/epics/pull/154/files#diff-f05a3743a8cccad2f21d1272c2cdee609b76747365619a062a935e41cf7561f9) to original gem