### PR TITLE
Add X.509 certificate hash methods and update ini letter template

### DIFF
--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -309,16 +309,31 @@ class Epics::Client
     Epics::X509Certificate.new(x_509_certificate_a_content)
   end
 
+  def x_509_certificate_a_hash
+    cert = OpenSSL::X509::Certificate.new(x_509_certificate_a_content)
+    Digest::SHA256.hexdigest(cert.to_der).upcase
+  end
+
   def x_509_certificate_x
     return if x_509_certificate_x_content.nil? || x_509_certificate_x_content.empty?
 
     Epics::X509Certificate.new(x_509_certificate_x_content)
   end
 
+  def x_509_certificate_x_hash
+    cert = OpenSSL::X509::Certificate.new(x_509_certificate_x_content)
+    Digest::SHA256.hexdigest(cert.to_der).upcase
+  end
+
   def x_509_certificate_e
     return if x_509_certificate_e_content.nil? || x_509_certificate_e_content.empty?
 
     Epics::X509Certificate.new(x_509_certificate_e_content)
+  end
+
+  def x_509_certificate_e_hash
+    cert = OpenSSL::X509::Certificate.new(x_509_certificate_e_content)
+    Digest::SHA256.hexdigest(cert.to_der).upcase
   end
 
   private

--- a/lib/epics/letter_renderer.rb
+++ b/lib/epics/letter_renderer.rb
@@ -1,7 +1,6 @@
 class Epics::LetterRenderer
   extend Forwardable
 
-  TEMPLATE_PATH = File.join(File.dirname(__FILE__), '../letter/', 'ini.erb')
   I18N_SCOPE = 'epics.letter'
 
   def initialize(client)
@@ -12,11 +11,22 @@ class Epics::LetterRenderer
     I18n.translate(key, **{ locale: @client.locale, scope: I18N_SCOPE }.merge(options))
   end
 
-  alias_method :t, :translate
+  alias t translate
 
-  def_delegators :@client, :host_id, :user_id, :partner_id, :a, :x, :e
+  def_delegators :@client, :host_id, :user_id, :partner_id, :a, :x, :e,
+                 :x_509_certificate_a_hash, :x_509_certificate_x_hash, :x_509_certificate_e_hash,
+                 :x_509_certificate_a_content, :x_509_certificate_x_content, :x_509_certificate_e_content
 
   def render(bankname)
-    ERB.new(File.read(TEMPLATE_PATH)).result(binding)
+    template_path = File.join(File.dirname(__FILE__), '../letter/', template_filename)
+    ERB.new(File.read(template_path)).result(binding)
+  end
+
+  def template_filename
+    use_x_509_certificate_template? ? 'ini_with_certs.erb' : 'ini.erb'
+  end
+
+  def use_x_509_certificate_template?
+    x_509_certificate_a_content && x_509_certificate_x_content && x_509_certificate_e_content
   end
 end

--- a/lib/epics/x_509_certificate.rb
+++ b/lib/epics/x_509_certificate.rb
@@ -3,7 +3,7 @@ class Epics::X509Certificate
 
   attr_reader :certificate
 
-  def_delegators :certificate, :issuer, :version, :to_pem
+  def_delegators :certificate, :issuer, :version
 
   def initialize(crt_content)
     @certificate = OpenSSL::X509::Certificate.new(crt_content)

--- a/lib/epics/x_509_certificate.rb
+++ b/lib/epics/x_509_certificate.rb
@@ -3,7 +3,7 @@ class Epics::X509Certificate
 
   attr_reader :certificate
 
-  def_delegators :certificate, :issuer, :version
+  def_delegators :certificate, :issuer, :version, :to_pem
 
   def initialize(crt_content)
     @certificate = OpenSSL::X509::Certificate.new(crt_content)

--- a/lib/letter/ini_with_certs.erb
+++ b/lib/letter/ini_with_certs.erb
@@ -1,0 +1,335 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta charset="UTF-8" />
+  <title>EBICS ini</title>
+  <style>
+      code {
+          font-size: 0.6rem;
+          overflow-wrap: break-word;
+      }
+      .code {
+          border-style: solid;
+          border-width: 1px;
+          padding: 8px;
+          background-color: azure;
+      }
+      .strong {
+          font-weight: bold;
+      }
+      h2 {
+          text-align: center;
+      }
+      td {
+          min-width: 150px;
+      }
+      table {
+          display: flex;
+          justify-content: center;
+      }
+      .column {
+          height: 100px;
+      }
+  </style>
+</head>
+<body>
+<div>
+  <h2><%= t('initialization_letter.a') %></h2>
+  <table>
+    <tr>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                <%= t('date') %> :
+              </td>
+              <td>
+                <%= Date.today.strftime('%d.%m.%Y') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('time') %> :
+              </td>
+              <td>
+                <%= Time.now.strftime('%H:%M:%S') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('recipient') %> :
+              </td>
+              <td>
+                <%= bankname %>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                Host-ID :
+              </td>
+              <td>
+                <%= host_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                User-ID :
+              </td>
+              <td>
+                <%= user_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                Partner-ID :
+              </td>
+              <td>
+                <%= partner_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('version') %> :
+              </td>
+              <td>
+                A006
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+    </tr>
+  </table>
+  <p><%= t('certificate') %> :</p>
+  <pre class="code"><code><%= x_509_certificate_a_content %></code></pre>
+  <p><%= t('hash') %> (SHA-256) :</p>
+  <p class="code"><code><%= x_509_certificate_a_hash %></code></p>
+  <p><%= t('confirmation') %></p>
+  <br/>
+  <br/>
+  <br/>
+  <br/>
+  <table>
+    <tr>
+      <td>
+        _________________________
+      </td>
+      <td>
+        _________________________
+      </td>
+      <td>
+        _________________________
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <%= t('issued_in') %>
+      </td>
+      <td>
+        <%= t('name') %>
+      </td>
+      <td>
+        <%= t('signature') %>
+      </td>
+    </tr>
+  </table>
+</div>
+<div style="page-break-after:always"></div>
+<div>
+  <h2><%= t('initialization_letter.x') %></h2>
+  <table>
+    <tr>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                <%= t('date') %> :
+              </td>
+              <td>
+                <%= Date.today.strftime('%d.%m.%Y') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('time') %> :
+              </td>
+              <td>
+                <%= Time.now.strftime('%H:%M:%S') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('recipient') %> :
+              </td>
+              <td>
+                <%= bankname %>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                Host-ID :
+              </td>
+              <td>
+                <%= host_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                User-ID :
+              </td>
+              <td>
+                <%= user_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                Partner-ID :
+              </td>
+              <td>
+                <%= partner_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('version') %> :
+              </td>
+              <td>
+                X002
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+    </tr>
+  </table>
+  <p><%= t('certificate') %> :</p>
+  <pre class="code"><code><%= x_509_certificate_x_content %></code></pre>
+  <p><%= t('hash') %> (SHA-256) :</p>
+  <p class="code"><code><%= x_509_certificate_x_hash %></code></p>
+</div>
+<div style="page-break-after:always"></div>
+<div>
+  <h2><%= t('initialization_letter.e') %></h2>
+  <table>
+    <tr>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                <%= t('date') %> :
+              </td>
+              <td>
+                <%= Date.today.strftime('%d.%m.%Y') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('time') %> :
+              </td>
+              <td>
+                <%= Time.now.strftime('%H:%M:%S') %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('recipient') %> :
+              </td>
+              <td>
+                <%= bankname %>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+      <td>
+        <div class="column">
+          <table>
+            <tr>
+              <td class="strong">
+                Host-ID :
+              </td>
+              <td>
+                <%= host_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                User-ID :
+              </td>
+              <td>
+                <%= user_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                Partner-ID :
+              </td>
+              <td>
+                <%= partner_id %>
+              </td>
+            </tr>
+            <tr>
+              <td class="strong">
+                <%= t('version') %> :
+              </td>
+              <td>
+                E002
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+    </tr>
+  </table>
+  <p><%= t('certificate') %> :</p>
+  <pre class="code"><code><%= x_509_certificate_e_content %></code></pre>
+  <p><%= t('hash') %> (SHA-256) :</p>
+  <p class="code"><code><%= x_509_certificate_e_hash %></code></p>
+  <p><%= t('confirmation') %></p>
+  <br/>
+  <br/>
+  <br/>
+  <br/>
+  <table>
+    <tr>
+      <td>
+        _________________________
+      </td>
+      <td>
+        _________________________
+      </td>
+      <td>
+        _________________________
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <%= t('issued_in') %>
+      </td>
+      <td>
+        <%= t('name') %>
+      </td>
+      <td>
+        <%= t('signature') %>
+      </td>
+    </tr>
+  </table>
+</div>
+</body>
+</html>

--- a/lib/letter/ini_with_certs.erb
+++ b/lib/letter/ini_with_certs.erb
@@ -111,7 +111,7 @@
   <p><%= t('certificate') %> :</p>
   <pre class="code"><code><%= x_509_certificate_a_content %></code></pre>
   <p><%= t('hash') %> (SHA-256) :</p>
-  <p class="code"><code><%= x_509_certificate_a_hash %></code></p>
+  <p class="code"><code><%= x_509_certificate_a_hash.scan(/../).join(":") %></code></p>
   <p><%= t('confirmation') %></p>
   <br/>
   <br/>
@@ -220,7 +220,7 @@
   <p><%= t('certificate') %> :</p>
   <pre class="code"><code><%= x_509_certificate_x_content %></code></pre>
   <p><%= t('hash') %> (SHA-256) :</p>
-  <p class="code"><code><%= x_509_certificate_x_hash %></code></p>
+  <p class="code"><code><%= x_509_certificate_x_hash.scan(/../).join(":") %></code></p>
 </div>
 <div style="page-break-after:always"></div>
 <div>
@@ -300,7 +300,7 @@
   <p><%= t('certificate') %> :</p>
   <pre class="code"><code><%= x_509_certificate_e_content %></code></pre>
   <p><%= t('hash') %> (SHA-256) :</p>
-  <p class="code"><code><%= x_509_certificate_e_hash %></code></p>
+  <p class="code"><code><%= x_509_certificate_e_hash.scan(/../).join(":") %></code></p>
   <p><%= t('confirmation') %></p>
   <br/>
   <br/>

--- a/lib/letter/locales/de.yml
+++ b/lib/letter/locales/de.yml
@@ -9,6 +9,7 @@ de:
       exponent: Exponent
       modulus: Modulus
       hash: Hash
+      certificate: Zertifikat
       bit: '%{bit} Bit'
       issued_in: Ort/Datum
       name: Name/Firma

--- a/lib/letter/locales/en.yml
+++ b/lib/letter/locales/en.yml
@@ -9,6 +9,7 @@ en:
       exponent: Exponent
       modulus: Modulus
       hash: Hash
+      certificate: Certificate
       bit: '%{bit} Bit'
       issued_in: Location/Date
       name: Name/Company

--- a/lib/letter/locales/fr.yml
+++ b/lib/letter/locales/fr.yml
@@ -9,6 +9,7 @@ fr:
       exponent: Exponent
       modulus: Modulus
       hash: Hash
+      certificate: Certificat
       bit: '%{bit} Bit'
       issued_in: Lieu/Date
       name: Nom/Société


### PR DESCRIPTION
When the EBICS Mandate requires X509 certificates, the 'ini letter' should be generated using the certificate data, rather than the key data.

sample
[Societe generale- Pennylane_ini_letter (2).pdf](https://github.com/user-attachments/files/20079731/Societe.generale-.Pennylane_ini_letter.2.pdf)



