### PR TITLE
Add error handling for no data available in H003 response

### DIFF
--- a/lib/epics/error.rb
+++ b/lib/epics/error.rb
@@ -67,6 +67,10 @@ class Epics::Error < StandardError
         "short_text" => "Synchronisation necessary",
         "meaning" => "Recovery of the transaction requires synchronisation between the customer system and the bank system Continuation of the transaction using the recovery point from the bank system's EBICS response",
       },
+      "090005" => {
+        "symbol" => "EBICS_NO_DOWNLOAD_DATA_AVAILABLE",
+        "short_text" => "No data are available at present for the selected download order type"
+      },
       "091002" => {
         "symbol" => "EBICS_INVALID_USER_OR_USER_STATE",
         "short_text" => "Subscriber unknown or subscriber state inadmissible",

--- a/spec/fixtures/xml/fdl_no_data-response_h003_ns.xml
+++ b/spec/fixtures/xml/fdl_no_data-response_h003_ns.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ebicsResponse xmlns="http://www.ebics.org/H003" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Revision="1" Version="H003"
+               xsi:schemaLocation="http://www.ebics.org/H003 http://www.ebics.org/H003/ebics_response.xsd">
+  <header authenticate="true">
+    <static>
+      <TransactionID>543</TransactionID>
+    </static>
+    <mutable>
+      <TransactionPhase>Initialisation</TransactionPhase>
+      <ReturnCode>090005</ReturnCode>
+      <ReportText>[EBICS_NO_DOWNLOAD_DATA_AVAILABLE]</ReportText>
+    </mutable>
+  </header>
+  <body>
+    <ReturnCode authenticate="true">000000</ReturnCode>
+  </body>
+</ebicsResponse>

--- a/spec/middleware/parse_ebics_spec.rb
+++ b/spec/middleware/parse_ebics_spec.rb
@@ -1,35 +1,130 @@
 # frozen_string_literal: true
 
 RSpec.describe Epics::ParseEbics do
-  subject do
-    Faraday.new do |builder|
-      builder.use Epics::ParseEbics
-      builder.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('/business_nok') { [200, {}, File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'xml', 'ebics_business_nok.xml'))] }
-        stub.post('/technical_nok') { [200, {}, File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'xml', 'ebics_technical_nok.xml'))] }
-        stub.post('/ok') { [200, {}, File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'xml', 'hpb_response_ebics_ns.xml'))] }
-        stub.post('/timeout') { raise Faraday::TimeoutError }
-        stub.post('/no_connection') { raise Faraday::ConnectionFailed, 'peer has finished all lan parties and gone home' }
+  let(:key) { File.read('spec/fixtures/SIZBN001.key') }
+  let(:base_client_params) do
+    [key, 'secret', 'https://194.180.18.30/ebicsweb/ebicsweb', 'SIZBN001', 'EBIX', 'EBICS']
+  end
+
+  let(:version) { Epics::Keyring::VERSION_25 }
+  let(:client) { Epics::Client.new(*base_client_params, { version: version }) }
+
+  let(:faraday_stubs) do
+    Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post('/business_nok') do
+        [200, {}, fixture_content('xml/ebics_business_nok.xml')]
+      end
+      stub.post('/technical_nok') do
+        [200, {}, fixture_content('xml/ebics_technical_nok.xml')]
+      end
+      stub.post('/ok') do
+        [200, {}, fixture_content('xml/hpb_response_ebics_ns.xml')]
+      end
+      stub.post('/timeout') { raise Faraday::TimeoutError }
+      stub.post('/no_connection') do
+        raise Faraday::ConnectionFailed, 'peer has finished all lan parties and gone home'
       end
     end
   end
 
-  it 'will handle errornous response with raising the related error class' do
-    expect { subject.post('/business_nok') }.to raise_error(Epics::Error::BusinessError, 'EBICS_PROCESSING_ERROR - During processing of the EBICS request, other business-related errors have ocurred')
-    expect { subject.post('/technical_nok') }.to raise_error(Epics::Error::TechnicalError, 'EBICS_AUTHENTICATION_FAILED - Authentication signature error')
+  subject(:faraday_client) do
+    Faraday.new do |builder|
+      builder.use described_class, client: client
+      builder.adapter :test, faraday_stubs
+    end
   end
 
-  it 'will parsed as Epics::Response' do
-    expect(subject.post('/ok').body).to be_kind_of(Epics::Response)
+  describe 'error handling' do
+    it 'raises BusinessError for business-related errors' do
+      expect { faraday_client.post('/business_nok') }
+        .to raise_error(
+          Epics::Error::BusinessError,
+          'EBICS_PROCESSING_ERROR - During processing of the EBICS request, other business-related errors have ocurred'
+        )
+    end
+
+    it 'raises TechnicalError for technical errors' do
+      expect { faraday_client.post('/technical_nok') }
+        .to raise_error(
+          Epics::Error::TechnicalError,
+          'EBICS_AUTHENTICATION_FAILED - Authentication signature error'
+        )
+    end
   end
 
-  context 'failures' do
-    it 'will raise a timeout correctly' do
-      expect { subject.post('/timeout') }.to raise_error(Faraday::TimeoutError, 'timeout')
+  describe 'successful response parsing' do
+    let(:response) { faraday_client.post('/ok') }
+
+    it 'parses response body as Epics::Response' do
+      expect(response.body).to be_an(Epics::Response)
     end
 
-    it 'will properly raise non-epics errors' do
-      expect { subject.post('/no_connection') }.to raise_error(Faraday::ConnectionFailed, 'peer has finished all lan parties and gone home')
+    it 'passes client to Epics::Response constructor' do
+      allow(Epics::Response).to receive(:new).and_call_original
+
+      response
+
+      expect(Epics::Response).to have_received(:new).with(client, anything)
     end
+  end
+
+  describe 'network failures' do
+    it 'propagates Faraday::TimeoutError' do
+      expect { faraday_client.post('/timeout') }
+        .to raise_error(Faraday::TimeoutError, 'timeout')
+    end
+
+    it 'propagates Faraday::ConnectionFailed' do
+      expect { faraday_client.post('/no_connection') }
+        .to raise_error(
+          Faraday::ConnectionFailed,
+          'peer has finished all lan parties and gone home'
+        )
+    end
+  end
+
+  describe 'version-specific behavior' do
+    context 'when using H003 version (VERSION_24)' do
+      let(:version) { Epics::Keyring::VERSION_24 }
+
+      let(:h003_stubs) do
+        Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.post('/fdl_h003_cd') do
+            [200, {}, fixture_content('xml/fdl_no_data-response_h003_ns.xml')]
+          end
+        end
+      end
+
+      subject(:h003_client) do
+        Faraday.new do |builder|
+          builder.use described_class, client: client
+          builder.adapter :test, h003_stubs
+        end
+      end
+
+      it 'handles FDL request with no data available' do
+        expect { h003_client.post('/fdl_h003_cd') }
+          .to raise_error(
+            Epics::Error::TechnicalError,
+            'EBICS_NO_DOWNLOAD_DATA_AVAILABLE - No data are available at present for the selected download order type'
+          )
+      end
+    end
+  end
+
+  describe 'middleware integration' do
+    it 'processes response through complete middleware chain' do
+      response = faraday_client.post('/ok')
+
+      expect(response).to be_success
+      expect(response.body).to respond_to(:technical_error?)
+      expect(response.body).to respond_to(:business_error?)
+    end
+  end
+
+  private
+
+  def fixture_content(path)
+    File.read(File.join('spec', 'fixtures', path))
   end
 end


### PR DESCRIPTION
[Sentry](https://pennylane.sentry.io/issues/6602859161/?project=1860673&referrer=Linear)
For some unknown reason, the FDL request response from CAISSE D'EPARGNE returns the business code inside the `mutable` node, which causes a TechnicalError::UNKNOWN_ERROR. This happens because the TechnicalError mapper doesn't recognize error code `090005` in this format. For other banks, `090005` is returned as a business error and is parsed correctly.
