### PR TITLE
Add signature_version handling to requests and refactor order parameters

### DIFF
--- a/lib/epics.rb
+++ b/lib/epics.rb
@@ -69,6 +69,7 @@ I18n.load_path += Dir[File.join(File.dirname(__FILE__), 'letter/locales', '*.yml
 module Epics
   DEFAULT_PRODUCT_NAME = 'EPICS - a ruby ebics kernel'
   DEFAULT_LOCALE = :de
+  DEFAULT_SIGNATURE_VERSION = 'A006'
 end
 
 Ebics = Epics

--- a/lib/epics/client.rb
+++ b/lib/epics/client.rb
@@ -3,7 +3,7 @@ class Epics::Client
 
   attr_accessor :passphrase, :url, :host_id, :user_id, :partner_id, :keys, :keys_content, :locale, :product_name,
                 :x_509_certificate_a_content, :x_509_certificate_x_content, :x_509_certificate_e_content, :debug_mode,
-                :current_order_id
+                :current_order_id, :signature_version
   attr_writer :iban, :bic, :name
   attr_reader :keyring
   
@@ -26,6 +26,7 @@ class Epics::Client
     self.x_509_certificate_x_content = options[:x_509_certificate_x_content]
     self.x_509_certificate_e_content = options[:x_509_certificate_e_content]
     self.current_order_id = options[:order_id] || 466560
+    self.signature_version = options[:signature_version] || Epics::DEFAULT_SIGNATURE_VERSION
     @keyring = Epics::Keyring.new(options[:version] || Epics::Keyring::VERSION_25)
   end
 

--- a/lib/epics/generic_request.rb
+++ b/lib/epics/generic_request.rb
@@ -16,7 +16,7 @@ class Epics::GenericRequest
     Time.now.utc.iso8601
   end
 
-  def_delegators :client, :host_id, :user_id, :partner_id
+  def_delegators :client, :host_id, :user_id, :partner_id, :signature_version
 
   def root
     'ebicsRequest'

--- a/lib/epics/generic_upload_request.rb
+++ b/lib/epics/generic_upload_request.rb
@@ -36,7 +36,7 @@ class Epics::GenericUploadRequest < Epics::GenericRequest
                             'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
                             'xsi:schemaLocation' => 'http://www.ebics.org/S001 http://www.ebics.org/S001/ebics_signature.xsd') do
         xml.OrderSignatureData do
-          xml.SignatureVersion 'A006'
+          xml.SignatureVersion signature_version
           xml.SignatureValue signature_value
           xml.PartnerID partner_id
           xml.UserID user_id

--- a/lib/epics/hcs.rb
+++ b/lib/epics/hcs.rb
@@ -78,7 +78,7 @@ class Epics::HCS < Epics::GenericUploadRequest
               xml.send('ds:Exponent', Base64.strict_encode64(client.a.key.e.to_s(2)))
             end
           end
-          xml.SignatureVersion 'A006'
+          xml.SignatureVersion client.signature_version
         end
         xml.PartnerID client.partner_id
         xml.UserID client.user_id

--- a/lib/epics/ini.rb
+++ b/lib/epics/ini.rb
@@ -44,7 +44,7 @@ class Epics::INI < Epics::GenericRequest
             }
             xml.TimeStamp timestamp
           }
-          xml.SignatureVersion 'A006'
+          xml.SignatureVersion signature_version
         }
         xml.PartnerID partner_id
         xml.UserID user_id


### PR DESCRIPTION
Some bank requires `A005` signature version instead of `A006`

EBICS error 
```
EBICS_KEYMGMT_UNSUPPORTED_VERSION_SIGNATURE - The algorithm version of the bank-technical signature key is not supported by the financial institution (order types INI, HCS and PUB)
```
[Thread](https://pennylane-org.slack.com/archives/C074T39H8ET/p1765466768926999)