### PR TITLE
BANK-1321Fix raising correct error when some banks put business-level error codes in the header position

### DIFF
--- a/lib/epics/error.rb
+++ b/lib/epics/error.rb
@@ -8,7 +8,11 @@ class Epics::Error < StandardError
 
   def initialize(code)
     @code = code
-    @error = self.class::ERRORS.fetch(code, {})
+    @error = self.class::ERRORS.fetch(code, nil) || fallback_errors.fetch(code, {})
+  end
+
+  def fallback_errors
+    {}
   end
 
   def symbol
@@ -177,6 +181,10 @@ class Epics::Error < StandardError
         "meaning" => "Case 1) File with order attribute \"DZHNN\" or \"OZHNN\" submitted with an orderId or Case 2) File with order attribute \"UZHNN\" submitted without an orderId or with orderID which is already used for \"DZHNN\" File with order attribute \"DZHNN\" submitted with an orderId",
       }
     }
+
+    def fallback_errors
+      BusinessError::ERRORS
+    end
   end
 
   class BusinessError < self
@@ -335,6 +343,10 @@ class Epics::Error < StandardError
         "short_text" => "The signatory has already signed the order on hand."
       }
     }
+
+    def fallback_errors
+      TechnicalError::ERRORS
+    end
   end
 
 end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Epics::Error::BusinessError do
-
   subject { Epics::Error::BusinessError.new(code) }
 
   before do
@@ -16,7 +15,6 @@ describe Epics::Error::BusinessError do
   let(:code) { '123' }
 
   describe '#to_s' do
-
     it 'returns a message composed of symbol and short text' do
       expect(subject.to_s).to eql('BOTTMUEHLE - home of awesome')
     end
@@ -39,5 +37,58 @@ describe Epics::Error::BusinessError do
       expect(subject.short_text).to eql('home of awesome')
     end
   end
+end
 
+describe 'Epics::Error cross-class fallback' do
+  describe Epics::Error::TechnicalError do
+    context 'when code exists only in BusinessError::ERRORS' do
+      subject { described_class.new('091210') }
+
+      it 'returns the correct symbol from BusinessError' do
+        expect(subject.to_s).to start_with('EBICS_X509_WRONG_KEY_USAGE')
+      end
+
+      it 'exposes the correct code' do
+        expect(subject.code).to eq('091210')
+      end
+    end
+
+    context 'when code exists in both ERRORS hashes (091002)' do
+      subject { described_class.new('091002') }
+
+      it 'uses TechnicalError meaning, not BusinessError' do
+        expect(subject.to_s).to start_with('EBICS_INVALID_USER_OR_USER_STATE')
+      end
+    end
+
+    context 'when code is unknown in both hashes' do
+      subject { described_class.new('999999') }
+
+      it 'returns EPICS_UNKNOWN' do
+        expect(subject.to_s).to eq('EPICS_UNKNOWN - unknown')
+      end
+    end
+  end
+
+  describe Epics::Error::BusinessError do
+    context 'when code exists only in TechnicalError::ERRORS' do
+      subject { described_class.new('061001') }
+
+      it 'returns the correct symbol from TechnicalError' do
+        expect(subject.to_s).to start_with('EBICS_AUTHENTICATION_FAILED')
+      end
+
+      it 'exposes the correct code' do
+        expect(subject.code).to eq('061001')
+      end
+    end
+
+    context 'when code is unknown in both hashes' do
+      subject { described_class.new('999999') }
+
+      it 'returns EPICS_UNKNOWN' do
+        expect(subject.to_s).to eq('EPICS_UNKNOWN - unknown')
+      end
+    end
+  end
 end


### PR DESCRIPTION

Some banks return business-level EBICS error codes (e.g. `091210` / `EBICS_X509_WRONG_KEY_USAGE`) in the **header/technical** position of the XML response rather than the body. The gem's middleware raises `TechnicalError` for header codes — but `TechnicalError::ERRORS` does not contain the key. The result is that valid, known errors are reported as `EPICS_UNKNOWN - unknown` instead of their actual description.

### Before
<img width="1510" height="338" alt="Screenshot 2026-04-24 at 14 30 30" src="https://github.com/user-attachments/assets/52114f86-e754-477c-bc7b-d1d126f52ce4" />

### After

<img width="1512" height="360" alt="Screenshot 2026-04-24 at 14 29 31" src="https://github.com/user-attachments/assets/3c52e4c6-e5da-4b78-9775-95a6462f6592" />
