### PR TITLE
Add license checks CI job 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,29 @@ jobs:
       - name: Run tests
         run: bundle exec rspec
 
+  license_checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler: "2.5.19"
+          bundler-cache: true
+      - name: Check licenses
+        run: bundle exec license_finder
+
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
     needs:
       - test
+      - license_checks
     if: always()
 
     steps:
       - name: Successful builds?
         run: |
           if ${{ needs.test.result != 'success' }}; then exit 1; fi
+          if ${{ needs.license_checks.result != 'success' }}; then exit 1; fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 /Gemfile.lock
 /_yardoc/
 /coverage/
-/doc/
+/doc/*
+!/doc/dependency_decisions.yml
 /pkg/
 /spec/reports/
 /tmp/

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
+  gem 'license_finder', require: false
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'rubocop-rspec'

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -23,9 +23,9 @@
     :why:
     :versions: []
     :when: 2026-05-07 08:48:04.629903000 Z
-- - :permit
-  - LGPL
-  - :who:
-    :why:
-    :versions: []
-    :when: 2026-05-07 08:48:35.357986000 Z
+- - :approve
+  - epics
+  - :why: >
+      This is LGPL-2.1, a weak copyleft license that we can use as long as we
+      comply with some requirements available here:
+      https://pennylane-org.slack.com/archives/C04HEQLHDTQ/p1741249208399559

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,0 +1,31 @@
+---
+- - :permit
+  - Simplified BSD
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-05-07 08:46:22.982184000 Z
+- - :permit
+  - ruby
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-05-07 08:46:30.129551000 Z
+- - :permit
+  - MIT
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-05-07 08:46:37.221213000 Z
+- - :permit
+  - Apache 2.0
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-05-07 08:48:04.629903000 Z
+- - :permit
+  - LGPL
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-05-07 08:48:35.357986000 Z


### PR DESCRIPTION
## Why do we need this?

List of all the reviewed [icenses](https://www.notion.so/scribetech/Open-Source-Libraries-1372276c03bf80109791f8de9e45ca41?source=copy_link) 
Adds license compliance checking to the CI pipeline, pending Legal approval of the permitted licenses.

- `license_checks` CI job — runs `license_finder` on every push/PR
- `doc/dependency_decisions.yml` — approved license types: MIT, Simplified BSD, ruby, LGPL, Apache 2.0
- CI Summary updated to require both `test` and `license_checks` to pass
- `license_finder` added to dev dependencies

Notion:
https://www.notion.so/scribetech/epics-f66c4df68f8f436b9a805961ea544f14?v=3923e422eb3c4eeb9420dab4df8336f7&source=copy_link
https://www.notion.so/scribetech/Repositories-hardening-1cfc3cfcebe842bc88c3ac4fae4a0506

<img width="841" height="93" alt="image" src="https://github.com/user-attachments/assets/2371508f-fb3e-4ebc-bfb8-55ab806e7624" />

